### PR TITLE
Add Discord ToS and Community Guidelines to Rules

### DIFF
--- a/RULES/messages/0
+++ b/RULES/messages/0
@@ -1,3 +1,5 @@
+As with everywhere on Discord, you must follow the rules outlined in the Discord ToS (<https://dis.gd/terms>) and Community Guidelines (<https://dis.gd/guidelines>).
+
 1. Don't be a jerk, racist, sexist, or discriminate. Don't use phrases including words such as "gay", "retarded", "virgin" as a slur or in any way that discriminates against a specific group of people. Changing the word in an attempt to bypass this rule (e.g "soft a" instead of "hard r") is prohibited.
 
 2. No lewd, gore, NSFW, or malicious content. This includes images and discussion of such topics. If what you're posting isn't PG-13 or lower, it doesn't belong here. Malicious content includes images/videos with the purpose of scaring people or crashing applications.
@@ -15,6 +17,4 @@ International: <http://www.suicide.org/international-suicide-hotlines.html>
 
 7. No warez, piracy, or malware.
 Discussion about emulation and emulators is allowed. However, pointing to where to download or redistributing copyrighted material without permission, in particular Celeste itself, is prohibited.
-
-8. Don't ruin other peoples' fun. Keep negativity to a reasonable level. We all get mad at times, but don't make all of your interactions in here negative, it drains everyone else.
 ​

--- a/RULES/messages/1
+++ b/RULES/messages/1
@@ -1,3 +1,5 @@
+8. Don't ruin other peoples' fun. Keep negativity to a reasonable level. We all get mad at times, but don't make all of your interactions in here negative, it drains everyone else.
+
 9. If someone is posting a pb/accomplishment in gaming or life, either congratulate them or keep silent, unless constructive criticism or feedback is requested. No one is claiming that their achievements are unbeatable, anything could be faster, so this doesn't need to be stated.
 
 10. Community members should strive to make others feel comfortable with their achievements without pushing them to do more beyond that. Peer pressure, valuing others' personal achievements/feelings as less than yours, or one-upping others with mentions aren't allowed.


### PR DESCRIPTION
Added text:
> As with everywhere on Discord, you must follow the rules outlined in the Discord ToS (<https://dis.gd/terms>) and Community Guidelines (<https://dis.gd/guidelines>).

Shifted rule 8 to second message due to word count limits.