### PR TITLE
Add #asset_making webhook

### DIFF
--- a/.github/workflows/webhooks.yml
+++ b/.github/workflows/webhooks.yml
@@ -17,6 +17,7 @@ jobs:
         env:
           RULES_WEBHOOK: ${{ secrets.RULES_WEBHOOK }}
           BUG_REPORTS_WEBHOOK: ${{ secrets.BUG_REPORTS_WEBHOOK }}
+          ASSET_MAKING_WEBHOOK: ${{ secrets.ASSET_MAKING_WEBHOOK }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/ASSET_MAKING/messages/0
+++ b/ASSET_MAKING/messages/0
@@ -1,0 +1,14 @@
+**Welcome to <#696801669517672658>!**
+**This is a place for Spriters and Musicians to discuss asset creation for Celeste mods, and to showcase what they've made.**
+
+Mappers, if you want to use an asset in your map, **ask for permission first**. Spriters/Musicians, if your work is freely usable by anyone, please tag it as such. 
+
+General information on Tilesets, FMOD and other guides for asset creation can be found under the Graphics and Audio sections of the [Everest Wiki](<https://github.com/EverestAPI/Resources/wiki>) respectively.
+
+Download the [Vanilla Graphics Dump](<https://drive.google.com/file/d/1ITwCI2uJ7YflAG0OwBR4uOUEJBjwTCet/view>) for version 1.4.0.0, structured in the same way as vanilla.
+
+For custom sprites, check out the [Community Asset Drive](<https://drive.google.com/drive/folders/1-Bb2gaw_7Qf0ITbEC-sQDbOugUJ9h1HE?usp=sharing>), full of tilesets, decals, and more for modders to use. If you want to contribute yourself, ping or DM <@437741699360489474>.
+
+If you're just getting started (or just want to up your game), you can also have a look at Pedro's (the spriter for Celeste) amazing [Pixel Art Tutorials](<https://lospec.com/pixel-art-tutorials/author/pedro-medeiros>).
+
+Musicians, you can download the FMOD project for Celeste from the [FMOD Downloads page](<https://www.fmod.com/download#learningresources>), under learning resources. Make sure to read the [Documentation and EULA](<https://www.fmod.com/resources/documentation-studio?version=2.01&page=appendix-a-celeste.html>).


### PR DESCRIPTION
Regular webhook messages support markdown-style links, unlike normal user messages.