### PR TITLE
Add support for webhook embeds

### DIFF
--- a/.github/scripts/webhooks.sh
+++ b/.github/scripts/webhooks.sh
@@ -19,6 +19,7 @@ webhook_status () {
 
     local IDS=()
     readarray -t IDS < "./$HOOK/ids"
+    CR=$'\r'; IDS=("${IDS[@]%$CR}") # remove pesky carriage returns
     for MSG in ${IDS[@]} ; do
         sleep 0.05
         if ! curl -o /dev/null -f "$WEBHOOK_URL/messages/$MSG" ; then

--- a/.github/scripts/webhooks.sh
+++ b/.github/scripts/webhooks.sh
@@ -50,10 +50,13 @@ echo 'Retrieving changed files'
 CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA)
 
 declare -a WEBHOOKS
-for file in $CHANGED
-do
-    if [[ "$(basename "$(dirname $file)")" == 'messages' && -e $file ]]
-    then
+for file in $CHANGED; do
+    folder=$(basename "$(dirname $file)")
+    if [[ "$folder" == 'embeds' && -e $file && -e ${file/embeds/messages} ]]; then
+        file=${file/embeds/messages}
+        folder=${folder/embeds/messages}
+    fi
+    if [[ "$folder" == 'messages' && -e $file ]]; then
         WEBHOOKS+=("$(echo $file | cut -d '/' -f1)")
     fi
 done

--- a/.github/scripts/webhooks.sh
+++ b/.github/scripts/webhooks.sh
@@ -42,7 +42,7 @@ send_message () {
             --arg content "$(cat $3/messages/$4)" \
             $embed_query \
             '{content: $content, embeds: $embeds, allowed_mentions: {parse: []}}' | \
-            perl -e '$sed = q(sed -e '\''s/"/\\\"/g'\''); $json = <>; $json =~ s/<\{\{ (.+?) \}\}>/`$sed $1 | awk '{print}' ORS='\\\\\\\\\\\\\\\\n'`/ge; print $json' \
+            perl -e '$json = <>; $json =~ s/<\{\{ (.+?) \}\}>/`cat $1 | jq -sR | head -c -3 | tail -c +2`/ge; print $json' \
         )"
 }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,25 +11,32 @@ jobs:
         run: |
           STATUS=0
           # check message length
+          if compgen -G $GITHUB_WORKSPACE/*/messages >/dev/null; then
           for message in $GITHUB_WORKSPACE/*/messages/*; do
             len=$(wc -m < $message)
             echo -e "$message\t$len"
-            if (( $len < 1 )) || (( $len > 2000 )); then
+            if ((($len < 1)) && [ ! -e ${message/messages/embeds} ] ) || (($len > 2000)); then
               echo "::error file=$message::Length of message ($len) out of allowed bounds."
               STATUS=1
             fi
           done
+          fi
 
           # verify embed formatting
+          if compgen -G $GITHUB_WORKSPACE/*/embeds >/dev/null; then
           for embed in $GITHUB_WORKSPACE/*/embeds/*; do
-            error=$(jq -ncj --slurpfile embeds $embed '{embeds:$embeds}' | \
-              perl -e '$sed = q(sed -e '\''s/"/\\\"/g'\''); $json = <>; $json =~ s/<\{\{ (.+?) \}\}>/`$sed $1 | awk '{print}' ORS='\\\\\\\\\\\\\\\\n'`/ge; print $json' | \
-                jq 2>&1 > /dev/null)
-            if [[ ! $? ]]; then
+            error=$(
+              set -o pipefail
+              { jq -ncj --slurpfile embeds $embed '{embeds:$embeds}' |
+                perl -e '$sed = q(sed -e '\''s/"/\\\"/g'\''); $json = <>; $json =~ s/<\{\{ (.+?) \}\}>/`$sed $1 | awk '{print}' ORS='\\\\\\\\\\\\\\\\n'`/ge; print $json' |
+                jq >/dev/null; } 2>&1
+            )
+            if [[ "$?" != "0" ]]; then
               echo "::error file=$embed::$error"
               STATUS=1
             fi
           done
+          fi
 
           # verify all webhooks have associated secrets
           for webhook in $GITHUB_WORKSPACE/*/; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,17 @@ jobs:
             fi
           done
 
+          # verify embed formatting
+          for embed in $GITHUB_WORKSPACE/*/embeds/*; do
+            error=$(jq -ncj --slurpfile embeds $embed '{embeds:$embeds}' | \
+              perl -e '$sed = q(sed -e '\''s/"/\\\"/g'\''); $json = <>; $json =~ s/<\{\{ (.+?) \}\}>/`$sed $1 | awk '{print}' ORS='\\\\\\\\\\\\\\\\n'`/ge; print $json' | \
+                jq 2>&1 > /dev/null)
+            if [[ ! $? ]]; then
+              echo "::error file=$embed::$error"
+              STATUS=1
+            fi
+          done
+
           # verify all webhooks have associated secrets
           for webhook in $GITHUB_WORKSPACE/*/; do
             webhook=$(basename "$webhook")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
             error=$(
               set -o pipefail
               { jq -ncj --slurpfile embeds $embed '{embeds:$embeds}' |
-                perl -e '$sed = q(sed -e '\''s/"/\\\"/g'\''); $json = <>; $json =~ s/<\{\{ (.+?) \}\}>/`$sed $1 | awk '{print}' ORS='\\\\\\\\\\\\\\\\n'`/ge; print $json' |
-                jq >/dev/null; } 2>&1
+                perl -e '$json = <>; $json =~ s/<\{\{ (.+?) \}\}>/`cat $1 | jq -sR | head -c -3 | tail -c +2`/ge; print $json' |
+                jq; } 2>&1
             )
             if [[ "$?" != "0" ]]; then
               echo "::error file=$embed::$error"


### PR DESCRIPTION
Adds support for sending [embeds](https://discord.com/developers/docs/resources/channel#embed-object) with webhook messages.

Usage:
-
For a message `$HOOK/messages/$ID`, read the JSON objects from `$HOOK/embeds/$ID` (not comma separated, see `--slurpfile` option for [invoking `jq`](https://stedolan.github.io/jq/manual/#Invokingjq)).
JSON embed objects can reference raw text files with `<{{ FILENAME }}>`, which will be inserted as an escaped JSON string, not including enclosing quotes (`--rawfile` option in above `jq` reference).