### PR TITLE
Update links

### DIFF
--- a/ASSET_MAKING/messages/0
+++ b/ASSET_MAKING/messages/0
@@ -7,7 +7,7 @@ General information on Tilesets, FMOD and other guides for asset creation can be
 
 Download the [Vanilla Graphics Dump](<https://drive.google.com/file/d/1ITwCI2uJ7YflAG0OwBR4uOUEJBjwTCet/view>) for version 1.4.0.0, structured in the same way as vanilla.
 
-For custom sprites, check out the [Community Asset Drive](<https://drive.google.com/drive/folders/13A0feEXS3kUHb_Q4K2w4xP8DEuBlgTip?usp=sharing>), full of tilesets, decals, and more for modders to use. If you want to contribute yourself, ping or DM <@558103204705861652>, <@166604761234145280>, <@354341658352943115>, <@257275513054298112>, or <@693036997027168268>.
+For custom sprites, check out the [Community Asset Drive](<https://maddie480.ovh/celeste/asset-drive>), full of tilesets, decals, and more for modders to use. If you want to contribute yourself, ping or DM <@558103204705861652>, <@166604761234145280>, <@354341658352943115>, <@257275513054298112>, or <@693036997027168268>.
 
 If you're just getting started (or just want to up your game), you can also have a look at Pedro's (the spriter for Celeste) amazing [Pixel Art Tutorials](<https://lospec.com/pixel-art-tutorials/author/pedro-medeiros>).
 

--- a/CELESTE/messages/1
+++ b/CELESTE/messages/1
@@ -1,6 +1,6 @@
 **Celeste Community Servers**
 
-[CelesteCommunity Events](<https://discord.gg/tKvK9Vu>) - Hub for races, bingo, and everything happening on the [CelesteCommunity Channel](<https://www.twitch.tv/celestecommunity>).
+[CelesteCommunity Events](<https://discord.gg/jDPpYueVWw>) - Hub for races, bingo, and everything happening on the [CelesteCommunity Channel](<https://www.twitch.tv/celestecommunity>).
 
 [Celeste Challenges](<https://discord.gg/NagmRMQ>) - All things challenge running, be it jumpless, dashless, grabless, or some other imposed limitation.
 


### PR DESCRIPTION
Change pin in celeste channel to correctly link celeste community server
Change pin in asset making to link to asset drive browser instead of the old google asset drive