### PR TITLE
Add appropriate references for new asset drive team role and re-organise links to the playtesting server

### DIFF
--- a/ASSET_MAKING/messages/0
+++ b/ASSET_MAKING/messages/0
@@ -7,7 +7,7 @@ General information on Tilesets, FMOD and other guides for asset creation can be
 
 Download the [Vanilla Graphics Dump](<https://drive.google.com/file/d/1ITwCI2uJ7YflAG0OwBR4uOUEJBjwTCet/view>) for version 1.4.0.0, structured in the same way as vanilla.
 
-For custom sprites, check out the [Community Asset Drive](<https://maddie480.ovh/celeste/asset-drive>), full of tilesets, decals, and more for modders to use. If you want to contribute yourself, ping or DM <@558103204705861652>, <@166604761234145280>, <@354341658352943115>, <@257275513054298112>, or <@693036997027168268>.
+For custom sprites, check out the [Community Asset Drive](<https://maddie480.ovh/celeste/asset-drive>), full of tilesets, decals, and more for modders to use. If you want to contribute yourself, ping <@&1217533882891763792>
 
 If you're just getting started (or just want to up your game), you can also have a look at Pedro's (the spriter for Celeste) amazing [Pixel Art Tutorials](<https://lospec.com/pixel-art-tutorials/author/pedro-medeiros>).
 

--- a/MAP_MAKING/messages/0
+++ b/MAP_MAKING/messages/0
@@ -14,4 +14,6 @@ For more information on adding and configuring features to your map, you can loo
 There is also [Documentation for Vanilla Entities](<https://github.com/EverestAPI/Resources/wiki/Entity-and-Trigger-Documentation>) and a [Custom Entity List](<https://max480-random-stuff.appspot.com/celeste/custom-entity-catalog>) that includes links to mod-specific documentation and shows which editor(s) each entity supports.
 Additional mod documentation may be available on the [Mod Resources Wiki](<https://github.com/EverestAPI/ModResources/wiki>).
 
+[Community Playtesting Server](<https://discord.gg/pmauV7EyMs>) - A server designed for finding playtesters for upcoming maps you are making and getting feedback on any celeste mod you are making.
+
 If you have any further questions, feel free to ask! There is lots of documentation in wikis, pins, gamebanana pages, and editor tooltips, but if you're still stuck people are happy to help out.

--- a/MODDING_GENERAL/messages/0
+++ b/MODDING_GENERAL/messages/0
@@ -6,3 +6,5 @@ To get started with modding, check out <#928422006985203822> and the [Everest Wi
 
 [Custom Map Golden List](<https://docs.google.com/spreadsheets/d/1v0yhceinMGr5alNekOxEkYCxXcYUsbtzMRVMezxbcVY>) - For completing or watching Golden Berry runs in modded maps, managed by <@&849715261347201095>.
 Make sure to also check out <#949113096113365003>. 
+
+[Community Playtesting Server](<https://discord.gg/pmauV7EyMs>) - A server designed for finding playtesters for upcoming maps you are making and getting feedback on any celeste mod you are making.

--- a/MODDING_WELCOME/messages/0
+++ b/MODDING_WELCOME/messages/0
@@ -13,6 +13,8 @@ For any further questions, or help with issues, feel free to ask in <#9533931604
 
 Found a bug with Everest, Olympus, or Lönn? Please ping <@&673394998913400873> / <@&683773388321456184>(Lönn) with enough info - preferably logs, which can be uploaded via drag and drop or <https://pastebin.com/>.
 
+Use assets from the [Community Drive](<https://maddie480.ovh/celeste/asset-drive>), or contribute to it by pinging the <@&1217533882891763792>
+
 Feel free to right-click <#683777712115941407>, <#449297822827937795> and / or <#817030587588018238> to get notified about all the updates you care about.
 
 For help with the multiplayer or randomizer Celeste mods, check out <#642429037389807617> and <#738558439227392082>.

--- a/ROLES/messages/0
+++ b/ROLES/messages/0
@@ -12,5 +12,6 @@ There are also individual roles for moderators who oversee each category of the 
 <@&673391557939953684> - Experienced modders able to assist with issues. Feel free to ping them for help.
 <@&683773388321456184> - Creators and maintainers of Lönn and Ahorn, the community map editors. Please ping them for bug reports.
 <@&930922325187129414> - Managers of the Celeste [GameBanana](<https://gamebanana.com/celeste>) section. Feel free to ping them for help.
+<@&1217533882891763792> - Maintainers of the [Asset Drive](<https://maddie480.ovh/celeste/asset-drive>) page.
 <@&483424202968268810> - Maintainers of the Celeste [speedrun.com](<https://speedrun.com/celeste_series>) page.
 <@&642413853187112962> - Verifiers on the Celeste [speedrun.com](<https://speedrun.com/celeste_series>) page. 


### PR DESCRIPTION
modding general playtesting server link to be moved into bot pin - will require removal of the manual pin
also add playtesting server link to map making channel's pin

asset making pin now refers to the asset drive team role instead of it's members
roles now mentions asset drive team
modding welcome lists the asset drive and how to contribute to it