### PR TITLE
Update speedrun moderators in speedrun welcome

### DIFF
--- a/SPEEDRUN_WELCOME/messages/0
+++ b/SPEEDRUN_WELCOME/messages/0
@@ -8,5 +8,5 @@ Before asking questions in <#672552986811301889>, read the Question Guidelines p
 
 You can organize races with other players in <#411946936267177984> by pinging the <@&411946831354920967> role, which is assignable in <#921651017727225906>.
 
-In order to send messages in <#417765135650783245>, you must have the <@&410182078462951444>, <@&511380746779230240>, or <@&411946831354920967> role, which can be assigned in <#921651017727225906>. Additionally, before posting to generate interest/submissions about an event you are running, please contact a <@&559418180880039948>, or if none are online, an <@&406682561683914753>. The current Speedrun Moderators are <@403759119758131211>, <@131997740971458560>, <@257631706687864833>, <@279027947523014657> and <@464892565817262081> (last updated <t:1698953940:d>).
+In order to send messages in <#417765135650783245>, you must have the <@&410182078462951444>, <@&511380746779230240>, or <@&411946831354920967> role, which can be assigned in <#921651017727225906>. Additionally, before posting to generate interest/submissions about an event you are running, please contact a <@&559418180880039948>, or if none are online, an <@&406682561683914753>. The current Speedrun Moderators are <@131997740971458560>, <@464892565817262081>, <@279027947523014657> and <@688091124602372151> (last updated <t:1717775700:d>).
 ​


### PR DESCRIPTION
The speedrun moderators listed in speedrun welcome were somewhat out of date, still listing tiyo and jacks (although jacks only removed more recently) and not listing ebre