### PR TITLE
Update contact staff message

### DIFF
--- a/CONTACT_STAFF/messages/0
+++ b/CONTACT_STAFF/messages/0
@@ -1,1 +1,7 @@
-If you would like to talk to the mod team privately, click the `📩 Create ticket` button on the message above and it'll open a temporary private channel with only you and the mod team. This can be used to report another user, to appeal server warns and mutes, or any other reason you may need to contact the mod team. If you need help with celeste or celeste modding, please use <#666197738026827786> or <#953393160464269402> instead. As the tickets are temporary and will be deleted afterwards, if you would like a transcript of the conversation for logging purposes please feel free to ask a moderator at any time and we will be able to provide that for you.
+If you would like to talk to the mod team, click the 📩 Create Ticket button on the message above to open a temporary, private channel.
+
+This can be used to report another user, appeal server warns and mutes, or any other reason you may need to contact the mod team.
+
+As tickets are temporary and will be deleted afterwards, if you would like a transcript of the conversation feel free to ask a moderator at any time and it will be provided to you.
+
+### __**If you need help with Celeste, Celestenet or Celeste modding, please use ⁠<#666197738026827786>, <#642429037389807617> or ⁠<#953393160464269402> instead**__


### PR DESCRIPTION
tickets were often being used for non-server related issues, change text in contact staff to hopefully reduce this by directly mentioning the channels for non-server issues